### PR TITLE
feat(pool): add opt-in claim cancellation

### DIFF
--- a/MAINTAINER_WORKFLOW.md
+++ b/MAINTAINER_WORKFLOW.md
@@ -112,6 +112,18 @@ When public packaging or JPMS metadata changes, inspect the built JAR as well as
 
 If a build inserts generated license headers into the working tree, remove them with the configured license goal before staging and confirm that only intentional source changes remain.
 
+For acquisition API changes, also run the checked-in compatibility probe after packaging:
+
+```powershell
+./scripts/verify-compatibility.ps1 -Java8Home '<JDK 8>' -ModernJavaHome '<JDK 21>'
+```
+
+It compiles a legacy allocator/client against the published 2.4.3 JAR, runs those unchanged classes with the candidate,
+and checks the new API on Java 8/21 classpaths and the modern module path. Run the compiled test suite with
+`mvn surefire:test -Djacoco.skip=true -Dnet.bytebuddy.experimental=true` under JDK 21 as a separate runtime lane;
+the extra property lets the existing test-only Byte Buddy version instrument Java 21 classes. The release compilation
+remains Java 8, and the standalone compatibility probes do not depend on Mockito or Byte Buddy.
+
 ## 7. Documentation and release notes
 
 `RELEASE.txt` retains the complete release history. `README.md` is the developer landing page: keep its dependency example, current version, JPMS name, and current-release summary aligned without turning it into a second full archive.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Maven Dependency Setup
 <dependency>
 	<groupId>com.github.bbottema</groupId>
 	<artifactId>generic-object-pool</artifactId>
-	<version>2.4.3</version>
+	<version>2.5.0</version>
 </dependency>
 ```
 
@@ -34,12 +34,12 @@ For JPMS applications, the published JAR declares the stable automatic module na
 
 ## Release Notes
 
-2.4.3 (7 September 2026)
+2.5.0 (8 September 2026)
 
-- [#20](https://github.com/bbottema/generic-object-pool/issues/20): Wake already-blocked claimers when invalidation frees capacity or the core pool adds replacements. These callers no longer need another release to make progress.
-- Concurrent invalidation of the same object now schedules cleanup only once and preserves pool counts.
-- Shutdown no longer observes the gap between invalidation and queued cleanup as an empty pool.
-- The public API, Java 8 baseline and JPMS module name are unchanged.
+- [#22](https://github.com/bbottema/generic-object-pool/issues/22): Optionally cancel pending claims and give acquisition one total time budget with `ClaimOptions` and `ClaimControl`.
+- Allocators can cooperate through `AllocationContext`; slow preparation no longer holds the pool's bookkeeping lock. Allocation and reuse callbacks remain serialized.
+- `PoolableObject.getDisposalCompletion()` acknowledges actual cleanup, separately from scheduling invalidation.
+- Existing claim methods and allocator subclasses remain supported. Java 8 and the JPMS module name are unchanged.
 
 ## Usage
 
@@ -110,6 +110,57 @@ Invalidation wakes ordinary callers that are already waiting for capacity. With 
 caller can create a replacement; a configured core pool also replenishes itself. Final cleanup remains asynchronous
 and need not finish before a replacement can be used. Matching claims still only take available objects: they do not
 allocate replacements themselves.
+
+#### Optional cancellation and a total acquisition budget
+
+For example, a cancelled export job should stop waiting for another database connection. Create the control before
+starting its worker, then retain it in the job's stop handler:
+
+```java
+ClaimControl claimControl = new ClaimControl();
+ClaimOptions options = ClaimOptions.withTimeout(30, TimeUnit.SECONDS)
+    .withClaimControl(claimControl);
+
+// On the job's worker; still an ordinary blocking call.
+PoolableObject<Foo> resource = pool.claim(options);
+// null: budget expired. CancellationException: stop requested. InterruptedException: worker interrupted.
+if (resource != null) {
+    try {
+        resource.getAllocatedObject().doWork();
+    } finally {
+        resource.release();
+    }
+}
+
+// In the stop handler, potentially on another thread:
+claimControl.requestCancellation();
+```
+
+Creating a control does not cancel anything. A control is thread-safe and one-shot; options are immutable and reusable.
+Each call starts a new monotonic budget covering selection by an outer pool, lock waiting, availability and preparation.
+`claimMatching(predicate, options)` has the same contract but never allocates resources. Zero budget starts no preparation.
+The legacy timeout methods retain their existing wait semantics; they do not gain a total deadline implicitly.
+
+Cancellation ends at handoff: requesting it after `claim` returns does not revoke the borrowed resource. It does not
+interrupt an executor thread. Allocator callbacks run on the claiming thread (core replenishment remains pool-owned),
+and allocation/reuse/release preparation remains serialized per pool. Final deallocation runs on the cleanup worker.
+
+Override `allocate(AllocationContext)` or `allocateForReuse(resource, AllocationContext)` to cooperate: check
+`context.throwIfCancellationRequested()`, use `context.getRemainingTime(unit)` for your own I/O timeout, and optionally
+register a quick, non-blocking abort action with `context.onCancellation(...)`. An earlier request invokes that handler
+immediately. Handler runtime exceptions are logged and ignored. Close registrations when their resource is no longer
+owned; the pool also detaches them before handoff. An allocator must clean up anything it creates but never returns.
+
+An old allocator that blocks in `allocate()` remains supported, but cannot be forcibly stopped: cancellation is recorded
+promptly, then the claim waits for allocation to exit and disposes any late resource instead of handing it off. Required
+cleanup can also outlast the acquisition budget. New context-aware claims settle only after that cleanup finishes;
+cleanup failures are reported (or suppressed on the original failure), not treated as successful disposal. A preparation
+exception after cancellation was requested is retained as the cause of `CancellationException`.
+
+`invalidate()` still only schedules cleanup. If physical disposal matters, use
+`resource.getDisposalCompletion().toCompletableFuture().get()`. A healthy `release()` does not complete this stage;
+the resource is still reusable. Each returned stage is detached from the pool's internal signal. Keep non-async stage
+callbacks short because they can run on the cleanup worker.
 
 #### Shutting down a pool
 

--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -4,6 +4,15 @@ https://github.com/bbottema/generic-object-pool
 RELEASE NOTES generic-object-pool
 
 
+v2.5.0 (8 September 2026)
+
+- #22: Add opt-in ClaimOptions and ClaimControl for cancellation of pending claims and a single total acquisition budget.
+- #22: Give allocators cooperative AllocationContext hooks while preserving existing allocator subclasses and serialized preparation callbacks.
+- #22: Run preparation outside pool bookkeeping, reserve capacity safely, and discard late resources when cancellation or timeout wins before handoff.
+- #22: Expose final disposal completion separately from asynchronous invalidation; cancellation never revokes a resource already handed to a borrower.
+- Existing claim methods, Java 8 baseline and JPMS automatic module name remain supported.
+
+
 v2.4.3 (7 September 2026)
 
 - #20: Wake blocked claimers when invalidation frees capacity and when background core-pool allocation publishes replacements, including partial allocation followed by failure.

--- a/scripts/verify-compatibility.ps1
+++ b/scripts/verify-compatibility.ps1
@@ -1,0 +1,37 @@
+param(
+    [Parameter(Mandatory = $true)][string] $Java8Home,
+    [Parameter(Mandatory = $true)][string] $ModernJavaHome,
+    [string] $Maven = 'mvn'
+)
+$ErrorActionPreference = 'Stop'
+$projectDirectory = Split-Path $PSScriptRoot -Parent
+Push-Location $projectDirectory
+try {
+    & $Maven dependency:copy '-Dartifact=com.github.bbottema:generic-object-pool:2.4.3' '-DoutputDirectory=target/compatibility-baseline'
+    if ($LASTEXITCODE -ne 0) { throw 'Could not resolve the released compatibility baseline' }
+    & $Maven dependency:build-classpath '-DincludeScope=runtime' '-Dmdep.outputFile=target/compatibility-classpath.txt'
+    if ($LASTEXITCODE -ne 0) { throw 'Could not resolve runtime dependencies' }
+    [xml] $projectPom = Get-Content pom.xml -Raw
+    $candidate = Join-Path $projectDirectory "target/generic-object-pool-$($projectPom.project.version).jar"
+    $dependencies = (Get-Content target/compatibility-classpath.txt -Raw).Trim()
+    $baseline = Join-Path $projectDirectory 'target/compatibility-baseline/generic-object-pool-2.4.3.jar'
+    $legacyClasses = New-Item -ItemType Directory -Force target/compatibility-legacy
+    $apiClasses = New-Item -ItemType Directory -Force target/compatibility-api
+    $moduleClasses = New-Item -ItemType Directory -Force target/compatibility-module
+    & "$Java8Home/bin/javac.exe" -cp "$baseline;$dependencies" -d $legacyClasses.FullName src/test/compatibility/LegacyAllocatorClient.java
+    if ($LASTEXITCODE -ne 0) { throw 'Legacy fixture did not compile against the previous release' }
+    & "$Java8Home/bin/javac.exe" -cp "$candidate;$dependencies" -d $apiClasses.FullName src/test/compatibility/consumer/PoolApiConsumer.java
+    if ($LASTEXITCODE -ne 0) { throw 'Public API fixture did not compile on Java 8' }
+    foreach ($runtime in @($Java8Home, $ModernJavaHome)) {
+        & "$runtime/bin/java.exe" -cp "$($legacyClasses.FullName);$candidate;$dependencies" LegacyAllocatorClient
+        if ($LASTEXITCODE -ne 0) { throw 'Previously compiled client failed' }
+        & "$runtime/bin/java.exe" -cp "$($apiClasses.FullName);$candidate;$dependencies" consumer.PoolApiConsumer
+        if ($LASTEXITCODE -ne 0) { throw 'Public API classpath client failed' }
+    }
+    & "$ModernJavaHome/bin/javac.exe" --module-path "$candidate;$dependencies" -d $moduleClasses.FullName src/test/compatibility/module-info.java src/test/compatibility/consumer/PoolApiConsumer.java
+    if ($LASTEXITCODE -ne 0) { throw 'Public API module-path compilation failed' }
+    & "$ModernJavaHome/bin/java.exe" --module-path "$($moduleClasses.FullName);$candidate;$dependencies" --add-modules ALL-MODULE-PATH --module pool.compatibility.consumer/consumer.PoolApiConsumer
+    if ($LASTEXITCODE -ne 0) { throw 'Public API module-path client failed' }
+} finally {
+    Pop-Location
+}

--- a/src/main/java/org/bbottema/genericobjectpool/AllocationContext.java
+++ b/src/main/java/org/bbottema/genericobjectpool/AllocationContext.java
@@ -1,0 +1,111 @@
+package org.bbottema.genericobjectpool;
+
+import org.bbottema.genericobjectpool.util.Timeout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Read-only cancellation state and remaining budget of one acquisition, shared through pool integration layers.
+ * Allocators may observe a request and register a cooperative abort, but cannot request cancellation themselves.
+ * They must apply the remaining budget to their own blocking work; this context cannot forcibly stop arbitrary code.
+ * Do not reuse a started context for an independent claim; start reusable {@link ClaimOptions} again instead.
+ *
+ * @since 2.5.0
+ */
+public final class AllocationContext {
+	private final long startedAtNanos;
+	private final long timeoutNanos;
+	private final ClaimControl claimControl;
+	private final List<CancellationRegistration> registrations = new ArrayList<>();
+	private boolean handlersDetached;
+
+	AllocationContext(final long startedAtNanos, final long timeoutNanos, final ClaimControl claimControl) {
+		this.startedAtNanos = startedAtNanos;
+		this.timeoutNanos = timeoutNanos;
+		this.claimControl = claimControl;
+	}
+
+	/** Returns whether the caller requested cancellation, not whether cleanup is finished. */
+	public boolean isCancellationRequested() {
+		return claimControl != null && claimControl.isCancellationRequested();
+	}
+
+	/** Lets a cooperative allocator stop before another side effect when the caller no longer wants the resource. */
+	public void throwIfCancellationRequested() {
+		if (isCancellationRequested()) {
+			throw new CancellationException("Resource claim cancellation requested");
+		}
+	}
+
+	/** Returns the remaining monotonic budget, rounded down in the supplied unit; unlimited returns Long.MAX_VALUE. */
+	public long getRemainingTime(final TimeUnit unit) {
+		requireNonNull(unit, "unit");
+		if (timeoutNanos == Long.MAX_VALUE) {
+			return Long.MAX_VALUE;
+		}
+		final long elapsed = System.nanoTime() - startedAtNanos;
+		return unit.convert(Math.max(0, timeoutNanos - elapsed), TimeUnit.NANOSECONDS);
+	}
+
+	/** Returns whether the acquisition budget has expired, independently of an explicit cancellation request. */
+	public boolean isTimedOut() {
+		return getRemainingTime(TimeUnit.NANOSECONDS) == 0;
+	}
+
+	/**
+	 * Narrows this running budget using a configured pool limit, without resetting its original starting time.
+	 * Integrations apply this before delegating to another pool, not after registering allocator callbacks.
+	 */
+	public AllocationContext limitedTo(final Timeout timeout) {
+		requireNonNull(timeout, "timeout");
+		final long limit = Math.max(0, timeout.getTimeUnit().toNanos(timeout.getDuration()));
+		return new AllocationContext(startedAtNanos, Math.min(timeoutNanos, limit), claimControl);
+	}
+
+	/**
+	 * Registers a quick, non-blocking action for an explicit cancellation request. An earlier request invokes it
+	 * immediately. Runtime exceptions are logged and ignored. Close the registration when its resource is no longer
+	 * owned; the pool also detaches remaining handlers before handoff or failed-claim settlement.
+	 * Deadline expiry is observed through the remaining budget, not by requesting cancellation of the caller's job.
+	 */
+	public CancellationRegistration onCancellation(final Runnable action) {
+		requireNonNull(action, "action");
+		synchronized (registrations) {
+			if (handlersDetached) {
+				throw new IllegalStateException("This acquisition has already finished preparing its resource");
+			}
+			final CancellationRegistration registration = claimControl == null ? () -> { } : claimControl.register(action);
+			registrations.add(registration);
+			return registration;
+		}
+	}
+
+	void detachCancellationHandlers() {
+		final List<CancellationRegistration> current;
+		synchronized (registrations) {
+			handlersDetached = true;
+			current = new ArrayList<>(registrations);
+			registrations.clear();
+		}
+		for (CancellationRegistration registration : current) {
+			registration.close();
+		}
+	}
+
+	boolean handOffIfActive(final Runnable handoff) {
+		final BooleanSupplier complete = () -> {
+			if (isTimedOut()) {
+				return false;
+			}
+			handoff.run();
+			return true;
+		};
+		return claimControl == null ? complete.getAsBoolean() : claimControl.handOffUnlessCancelled(complete);
+	}
+}

--- a/src/main/java/org/bbottema/genericobjectpool/Allocator.java
+++ b/src/main/java/org/bbottema/genericobjectpool/Allocator.java
@@ -15,6 +15,18 @@ public abstract class Allocator<T> {
 	 */
 	@NotNull
 	public abstract T allocate();
+
+	/**
+	 * Prepares a new resource for an opt-in claim. Override to observe cancellation and apply the remaining budget
+	 * to blocking work. This default preserves existing allocator implementations by delegating to {@link #allocate()}.
+	 * The allocator owns partially created resources if it throws before returning one to the pool.
+	 *
+	 * @since 2.5.0
+	 */
+	@NotNull
+	public T allocate(@NotNull final AllocationContext context) {
+		return allocate();
+	}
 	
 	/**
 	 * Uninitialize an instance which has been released back to the pool, until it is claimed again.
@@ -28,6 +40,17 @@ public abstract class Allocator<T> {
 	 */
 	public void allocateForReuse(T object) {
 		// overridable hook
+	}
+
+	/**
+	 * Prepares an existing resource for an opt-in claim, with cooperative cancellation and a remaining budget.
+	 * Delegates to {@link #allocateForReuse(Object)} for existing allocators. The pool disposes the resource if
+	 * preparation fails or the claim is cancelled before handoff.
+	 *
+	 * @since 2.5.0
+	 */
+	public void allocateForReuse(final T object, @NotNull final AllocationContext context) {
+		allocateForReuse(object);
 	}
 	
 	/**

--- a/src/main/java/org/bbottema/genericobjectpool/CancellationRegistration.java
+++ b/src/main/java/org/bbottema/genericobjectpool/CancellationRegistration.java
@@ -1,0 +1,14 @@
+package org.bbottema.genericobjectpool;
+
+/**
+ * Lifetime of a cooperative allocator's cancellation handler. Close it before releasing its resource for reuse.
+ * Closing is idempotent and waits for an already-running handler to exit; handlers must therefore be non-blocking.
+ *
+ * @since 2.5.0
+ */
+@FunctionalInterface
+public interface CancellationRegistration extends AutoCloseable {
+	/** Detaches the handler without requesting cancellation. */
+	@Override
+	void close();
+}

--- a/src/main/java/org/bbottema/genericobjectpool/ClaimAttempt.java
+++ b/src/main/java/org/bbottema/genericobjectpool/ClaimAttempt.java
@@ -1,0 +1,119 @@
+package org.bbottema.genericobjectpool;
+
+import org.bbottema.genericobjectpool.util.Timeout;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+/** Keeps legacy wait semantics separate from one cancellable, total-budget acquisition. */
+final class ClaimAttempt implements AutoCloseable {
+
+	private static final long RECHECK_NANOS = TimeUnit.MILLISECONDS.toNanos(10);
+	private final Timeout legacyTimeout;
+	private final AllocationContext context;
+	private final boolean matching;
+	private final long startedAtNanos = System.nanoTime();
+	private final Semaphore wakeUp = new Semaphore(0);
+	private boolean waited;
+
+	ClaimAttempt(final Timeout legacyTimeout, final AllocationContext context, final boolean matching) {
+		this.legacyTimeout = legacyTimeout;
+		this.context = context;
+		this.matching = matching;
+		if (context != null) {
+			context.onCancellation(this::signal);
+		}
+	}
+
+	AllocationContext getContext() {
+		return context;
+	}
+
+	boolean isControlled() {
+		return context != null;
+	}
+
+	boolean hasWaited() {
+		return waited;
+	}
+
+	boolean canContinue() throws InterruptedException {
+		if (context == null) {
+			return true;
+		}
+		context.throwIfCancellationRequested();
+		if (Thread.interrupted()) {
+			throw new InterruptedException("Resource claim interrupted");
+		}
+		return !context.isTimedOut();
+	}
+
+	boolean acquire(final Lock lock) throws InterruptedException {
+		if (context == null) {
+			lock.lock();
+			return true;
+		}
+		while (canContinue()) {
+			if (lock.tryLock(Math.min(RECHECK_NANOS, context.getRemainingTime(TimeUnit.NANOSECONDS)), TimeUnit.NANOSECONDS)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	void prepareToWait() {
+		wakeUp.drainPermits();
+	}
+
+	void signal() {
+		wakeUp.release();
+	}
+
+	boolean awaitAvailability() throws InterruptedException {
+		waited = true;
+		if (!canContinue()) {
+			return false;
+		}
+		final long remaining = remainingWaitNanos();
+		final long interval = matching ? Math.min(RECHECK_NANOS, remaining) : remaining;
+		final boolean signalled = wakeUp.tryAcquire(interval, TimeUnit.NANOSECONDS);
+		return canContinue() && (signalled || matching && remainingWaitNanos() > 0);
+	}
+
+	private long remainingWaitNanos() {
+		if (context != null) {
+			return context.getRemainingTime(TimeUnit.NANOSECONDS);
+		}
+		final long duration = legacyTimeout.getTimeUnit().toNanos(legacyTimeout.getDuration());
+		return matching && duration != Long.MAX_VALUE ? Math.max(0, duration - (System.nanoTime() - startedAtNanos)) : duration;
+	}
+
+	boolean handOff(final Runnable handoff) throws InterruptedException {
+		if (!canContinue()) {
+			return false;
+		}
+		if (context != null) {
+			return context.handOffIfActive(handoff);
+		}
+		handoff.run();
+		return true;
+	}
+
+	Throwable preparationFailure(final Throwable failure) {
+		if (context != null && context.isCancellationRequested() && !(failure instanceof CancellationException) && !(failure instanceof Error)) {
+			final CancellationException cancelled = new CancellationException("Resource claim cancellation requested");
+			cancelled.initCause(failure);
+			return cancelled;
+		}
+		return failure;
+	}
+
+	@Override
+	public void close() {
+		if (context != null) {
+			context.detachCancellationHandlers();
+		}
+	}
+}

--- a/src/main/java/org/bbottema/genericobjectpool/ClaimControl.java
+++ b/src/main/java/org/bbottema/genericobjectpool/ClaimControl.java
@@ -1,0 +1,102 @@
+package org.bbottema.genericobjectpool;
+
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BooleanSupplier;
+
+import static java.util.Objects.requireNonNull;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * Optional, caller-owned control over pending resource claims. Creating a control does not cancel anything.
+ * A job may share one control among its pending claims; cancellation never revokes a resource already handed off.
+ * Controls are thread-safe and one-shot: use a new instance for another job.
+ *
+ * @since 2.5.0
+ */
+public final class ClaimControl {
+
+	private static final Logger LOGGER = getLogger(ClaimControl.class);
+	private final List<Registration> registrations = new ArrayList<>();
+	private volatile boolean cancellationRequested;
+
+	/**
+	 * Requests cancellation of the associated pending claims. Does not wait for their allocation or cleanup to finish.
+	 * Registered cooperative handlers run on this thread and must be quick and non-blocking.
+	 *
+	 * @return true for the first request, not confirmation that all associated work has stopped
+	 */
+	public boolean requestCancellation() {
+		final List<Registration> pending;
+		synchronized (this) {
+			if (cancellationRequested) {
+				return false;
+			}
+			cancellationRequested = true;
+			pending = new ArrayList<>(registrations);
+			registrations.clear();
+		}
+		for (Registration registration : pending) {
+			registration.notifyCancellation();
+		}
+		return true;
+	}
+
+	/** Returns whether cancellation was requested, which is different from confirmation that a claim has settled. */
+	public boolean isCancellationRequested() {
+		return cancellationRequested;
+	}
+
+	CancellationRegistration register(final Runnable action) {
+		final Registration registration = new Registration(requireNonNull(action, "action"));
+		final boolean alreadyRequested;
+		synchronized (this) {
+			alreadyRequested = cancellationRequested;
+			if (!alreadyRequested) {
+				registrations.add(registration);
+			}
+		}
+		if (alreadyRequested) {
+			registration.notifyCancellation();
+		}
+		return registration;
+	}
+
+	/** The pool already holds its bookkeeping lock; the supplied handoff must contain no blocking work. */
+	synchronized boolean handOffUnlessCancelled(final BooleanSupplier handoff) {
+		return !cancellationRequested && handoff.getAsBoolean();
+	}
+
+	private final class Registration implements CancellationRegistration {
+		private final Runnable action;
+		private boolean active = true;
+
+		private Registration(final Runnable action) {
+			this.action = action;
+		}
+
+		private synchronized void notifyCancellation() {
+			if (active) {
+				active = false;
+				try {
+					action.run();
+				} catch (RuntimeException failure) {
+					LOGGER.warn("Ignoring a failed claim cancellation handler", failure);
+				}
+			}
+		}
+
+		@Override
+		public void close() {
+			synchronized (this) {
+				// Waiting for an already-running handler fences it out of the next borrower's lifetime.
+				active = false;
+			}
+			synchronized (ClaimControl.this) {
+				registrations.remove(this);
+			}
+		}
+	}
+}

--- a/src/main/java/org/bbottema/genericobjectpool/ClaimOptions.java
+++ b/src/main/java/org/bbottema/genericobjectpool/ClaimOptions.java
@@ -1,0 +1,48 @@
+package org.bbottema.genericobjectpool;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Immutable, reusable settings for opt-in acquisition. The timeout covers this claim, including lock waiting and
+ * preparation; non-cooperative callbacks and required cleanup may delay its return beyond that budget.
+ * A retained {@link ClaimControl} remains live rather than being copied as a snapshot.
+ *
+ * @since 2.5.0
+ */
+public final class ClaimOptions {
+	private final long timeoutNanos;
+	private final ClaimControl claimControl;
+
+	private ClaimOptions(final long timeoutNanos, final ClaimControl claimControl) {
+		this.timeoutNanos = timeoutNanos;
+		this.claimControl = claimControl;
+	}
+
+	/** Creates settings with a non-negative total acquisition budget; zero never starts preparation. */
+	public static ClaimOptions withTimeout(final long duration, final TimeUnit unit) {
+		if (duration < 0) {
+			throw new IllegalArgumentException("Claim timeout must not be negative");
+		}
+		return new ClaimOptions(requireNonNull(unit, "unit").toNanos(duration), null);
+	}
+
+	/** Creates settings with no time limit; a claim control can still cancel the acquisition. */
+	public static ClaimOptions withoutTimeout() {
+		return new ClaimOptions(Long.MAX_VALUE, null);
+	}
+
+	/** Returns new settings using this control; neither object requests cancellation merely by being configured. */
+	public ClaimOptions withClaimControl(final ClaimControl control) {
+		return new ClaimOptions(timeoutNanos, requireNonNull(control, "control"));
+	}
+
+	/**
+	 * Starts one monotonic acquisition budget. Pool integrations call this before selection and pass the resulting
+	 * context down without restarting it. Ordinary callers can pass these options directly to a pool's claim method.
+	 */
+	public AllocationContext start() {
+		return new AllocationContext(System.nanoTime(), timeoutNanos, claimControl);
+	}
+}

--- a/src/main/java/org/bbottema/genericobjectpool/GenericObjectPool.java
+++ b/src/main/java/org/bbottema/genericobjectpool/GenericObjectPool.java
@@ -8,19 +8,19 @@ import org.bbottema.genericobjectpool.util.Timeout;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Predicate;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newSingleThreadExecutor;
@@ -30,480 +30,606 @@ import static org.bbottema.genericobjectpool.util.ForeverTimeout.WAIT_FOREVER;
 public class GenericObjectPool<T> {
 
 	private static final int DEALLOCATION_WAIT_MS = 100;
-	private static final int MATCHING_CLAIM_RECHECK_INTERVAL_MS = 10;
-	
+
 	@NotNull private final Lock claimLock = new ReentrantLock();
+	// Keep existing allocators serialized, without holding up cancellation, metrics or pool bookkeeping.
+	@NotNull private final Lock allocatorLock = new ReentrantLock();
 	@NotNull private final Lock deallocateLock = new ReentrantLock();
 	@NotNull private final LinkedList<PoolableObject<T>> available = new LinkedList<>();
 	@NotNull private final LinkedList<PoolableObject<T>> waitingForDeallocation = new LinkedList<>();
-	@NotNull private final LinkedList<Condition> objectAvailableConditions = new LinkedList<>();
+	@NotNull private final LinkedList<ClaimAttempt> waitingClaims = new LinkedList<>();
 	@NotNull private final Condition objectWaitingForDeallocation = deallocateLock.newCondition();
-	
+
 	@NotNull @Getter private final PoolConfig<T> poolConfig;
 	@NotNull @Getter private final Allocator<T> allocator;
-	
 	@Nullable private volatile Future<Void> shutdownSequence;
-	
-	@NotNull private final AtomicInteger currentlyClaimed = new AtomicInteger();
+
 	@NotNull private final AtomicInteger currentlyDeallocating = new AtomicInteger();
 	@NotNull private final AtomicLong totalAllocated = new AtomicLong();
 	@NotNull private final AtomicLong totalClaimed = new AtomicLong();
-	
+	// All four counts below are protected by claimLock. Reservations consume capacity before allocation starts.
+	private int currentlyAllocated;
+	private int currentlyClaimed;
+	private int pendingAllocations;
+	private int pendingClaims;
+
 	public GenericObjectPool(final PoolConfig<T> poolConfig, @NotNull final Allocator<T> allocator) {
-		this.poolConfig = poolConfig;
-		this.allocator = allocator;
+		this.poolConfig = requireNonNull(poolConfig, "poolConfig");
+		this.allocator = requireNonNull(allocator, "allocator");
 		poolConfig.getThreadFactory().newThread(new AutoAllocator()).start();
 		poolConfig.getThreadFactory().newThread(new AutoDeallocator()).start();
 	}
-	
-	/**
-	 * Delegates to {@link #claim(Timeout)} with unlimited timeout.
-	 */
+
+	/** Delegates to {@link #claim(Timeout)} with unlimited timeout. */
 	@NotNull
-	@SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "False positive")
+	@SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "Unlimited legacy claims do not time out")
 	public PoolableObject<T> claim() throws InterruptedException {
 		return requireNonNull(claim(WAIT_FOREVER));
 	}
-	
-	/**
-	 * Delegates to {@link #claim(Timeout)}.
-	 */
+
+	/** Delegates to {@link #claim(Timeout)}. */
 	@Nullable
 	public PoolableObject<T> claim(final long timeout, final TimeUnit timeUnit) throws InterruptedException {
 		return claim(new Timeout(timeout, timeUnit));
 	}
-	
+
 	/**
-	 * Will claim available object, create a new one if there is room to grow the pool, or else wait until either become true.
+	 * Claims an available object, creates one if there is room, or waits for either to become possible.
+	 * The legacy timeout limits each availability wait, not lock acquisition or allocator callbacks.
 	 *
-	 * @throws IllegalStateException if you try a new claim while the pool is shut down
-	 * @throws InterruptedException  if the pool was waiting and the pool shut down in the mean time
+	 * @throws IllegalStateException if a new claim is made after shutdown starts
+	 * @throws InterruptedException if a waiting claim is interrupted or the pool shuts down while it waits
 	 */
-	@SuppressWarnings("WeakerAccess")
 	@Nullable
-	public PoolableObject<T> claim(final Timeout timeout) throws InterruptedException, IllegalStateException {
-		claimLock.lock();
-		try {
-			return claimOrCreateOrWaitUntilAvailable(timeout);
-		} finally {
-			claimLock.unlock();
-		}
+	public PoolableObject<T> claim(final Timeout timeout) throws InterruptedException {
+		return claimResource(new ClaimAttempt(requireNonNull(timeout, "timeout"), null, false), null);
 	}
 
 	/**
-	 * Delegates to {@link #claimMatching(Predicate, Timeout)}.
+	 * Claims using one total acquisition budget and optional cancellation control. Preparation stays on the caller's
+	 * thread. Returns null on timeout and throws {@link java.util.concurrent.CancellationException} on cancellation.
+	 * A non-cooperative allocator or required disposal may delay settlement, but cannot cause a cancelled resource
+	 * to be handed off. After successful return, acquisition cancellation no longer affects the borrowed object.
+	 *
+	 * @since 2.5.0
 	 */
 	@Nullable
-	public PoolableObject<T> claimMatching(@NotNull final Predicate<PoolableObject<T>> predicate, final long timeout, final TimeUnit timeUnit) throws InterruptedException {
+	public PoolableObject<T> claim(final ClaimOptions options) throws InterruptedException {
+		return claimWithContext(requireNonNull(options, "options").start());
+	}
+
+	/**
+	 * Integration entry point for a budget already started by an outer pool. Do not restart the context between layers
+	 * or reuse it for independent claims; ordinary callers should use {@link #claim(ClaimOptions)}.
+	 *
+	 * @since 2.5.0
+	 */
+	@Nullable
+	public PoolableObject<T> claimWithContext(final AllocationContext context) throws InterruptedException {
+		return claimResource(new ClaimAttempt(null, requireNonNull(context, "context"), false), null);
+	}
+
+	/** Delegates to {@link #claimMatching(Predicate, Timeout)}. */
+	@Nullable
+	public PoolableObject<T> claimMatching(@NotNull final Predicate<PoolableObject<T>> predicate,
+			final long timeout, final TimeUnit timeUnit) throws InterruptedException {
 		return claimMatching(predicate, new Timeout(timeout, timeUnit));
 	}
 
 	/**
-	 * Claims an already available object matching the predicate, or waits until one becomes available or matches due to time passing.
-	 * <p>
-	 * This method does not allocate new objects. Keep the predicate fast and side-effect free; it is evaluated while the pool claim lock is held.
+	 * Claims an already available matching object, without allocating a new one. The predicate is rechecked as time
+	 * passes; keep it fast and side-effect free because it runs under the bookkeeping lock.
 	 */
-	@SuppressWarnings("WeakerAccess")
 	@Nullable
-	public PoolableObject<T> claimMatching(@NotNull final Predicate<PoolableObject<T>> predicate, final Timeout timeout) throws InterruptedException, IllegalStateException {
+	public PoolableObject<T> claimMatching(@NotNull final Predicate<PoolableObject<T>> predicate, final Timeout timeout)
+			throws InterruptedException {
 		requireNonNull(predicate, "predicate");
+		return claimResource(new ClaimAttempt(requireNonNull(timeout, "timeout"), null, true), predicate);
+	}
+
+	/**
+	 * Matching-only counterpart of {@link #claim(ClaimOptions)}, with the same cancellation and cleanup contract.
+	 * Never creates a new resource.
+	 *
+	 * @since 2.5.0
+	 */
+	@Nullable
+	public PoolableObject<T> claimMatching(@NotNull final Predicate<PoolableObject<T>> predicate, final ClaimOptions options)
+			throws InterruptedException {
+		return claimMatchingWithContext(predicate, requireNonNull(options, "options").start());
+	}
+
+	/** Integration counterpart of {@link #claimMatching(Predicate, ClaimOptions)} that preserves an outer budget. */
+	@Nullable
+	public PoolableObject<T> claimMatchingWithContext(@NotNull final Predicate<PoolableObject<T>> predicate,
+			final AllocationContext context) throws InterruptedException {
+		requireNonNull(predicate, "predicate");
+		return claimResource(new ClaimAttempt(null, requireNonNull(context, "context"), true), predicate);
+	}
+
+	@Nullable
+	private PoolableObject<T> claimResource(final ClaimAttempt attempt, final Predicate<PoolableObject<T>> predicate)
+			throws InterruptedException {
+		try (ClaimAttempt ignored = attempt) {
+			while (attempt.acquire(claimLock)) {
+				final Reservation reservation;
+				try {
+					ensureOpenFor(attempt);
+					reservation = reserveResource(predicate);
+					if (reservation == null) {
+						attempt.prepareToWait();
+						waitingClaims.add(attempt);
+					}
+				} finally {
+					claimLock.unlock();
+				}
+				if (reservation != null) {
+					return prepareAndHandOff(reservation, attempt);
+				}
+				if (!waitForAvailability(attempt)) {
+					return null;
+				}
+			}
+			return null;
+		}
+	}
+
+	private void ensureOpenFor(final ClaimAttempt attempt) throws InterruptedException {
+		if (isShuttingDown()) {
+			if (attempt.hasWaited()) {
+				throw new InterruptedException("Pool is shutting down");
+			}
+			throw new IllegalStateException("Pool has been shutdown");
+		}
+	}
+
+	private Reservation reserveResource(final Predicate<PoolableObject<T>> predicate) {
+		for (Iterator<PoolableObject<T>> iterator = available.iterator(); iterator.hasNext(); ) {
+			final PoolableObject<T> entry = iterator.next();
+			if (predicate == null || predicate.test(entry)) {
+				iterator.remove();
+				entry.setCurrentPoolStatus(PoolableObject.PoolStatus.PREPARING);
+				pendingClaims++;
+				return new Reservation(entry);
+			}
+		}
+		return predicate == null && currentlyAllocated + pendingAllocations < poolConfig.getMaxPoolsize()
+				? reserveAllocation() : null;
+	}
+
+	private Reservation reserveAllocation() {
+		pendingAllocations++;
+		pendingClaims++;
+		return new Reservation(null);
+	}
+
+	private boolean waitForAvailability(final ClaimAttempt attempt) throws InterruptedException {
+		try {
+			final boolean signalled = attempt.awaitAvailability();
+			ensureOpenFor(attempt);
+			return signalled;
+		} finally {
+			claimLock.lock();
+			try {
+				waitingClaims.remove(attempt);
+			} finally {
+				claimLock.unlock();
+			}
+		}
+	}
+
+	private PoolableObject<T> prepareAndHandOff(final Reservation reservation, final ClaimAttempt attempt)
+			throws InterruptedException {
+		PoolableObject<T> prepared = reservation.existing;
+		Throwable failure = null;
+		try {
+			prepared = prepareResource(reservation, attempt);
+			// Detach outside bookkeeping: a cooperative handler might still be finishing its short abort action.
+			attempt.close();
+			if (prepared != null && handOff(reservation, prepared, attempt)) {
+				return prepared;
+			}
+			attempt.canContinue();
+		} catch (RuntimeException | Error | InterruptedException preparationFailure) {
+			failure = attempt.preparationFailure(preparationFailure);
+		} finally {
+			attempt.close();
+		}
+		failure = disposeFailedReservation(reservation, prepared, attempt, failure);
+		rethrowFailure(failure);
+		attempt.canContinue();
+		return null;
+	}
+
+	private PoolableObject<T> prepareResource(final Reservation reservation, final ClaimAttempt attempt) throws InterruptedException {
+		if (!attempt.acquire(allocatorLock)) {
+			return reservation.existing;
+		}
+		try {
+			if (!attempt.canContinue()) {
+				return reservation.existing;
+			}
+			if (reservation.existing == null) {
+				final T resource = attempt.isControlled() ? allocator.allocate(attempt.getContext()) : allocator.allocate();
+				return new PoolableObject<>(this, requireNonNull(resource, "Allocated resource"));
+			}
+			if (attempt.isControlled()) {
+				allocator.allocateForReuse(reservation.existing.getAllocatedObject(), attempt.getContext());
+			} else {
+				allocator.allocateForReuse(reservation.existing.getAllocatedObject());
+			}
+			return reservation.existing;
+		} finally {
+			allocatorLock.unlock();
+		}
+	}
+
+	private boolean handOff(final Reservation reservation, final PoolableObject<T> prepared, final ClaimAttempt attempt)
+			throws InterruptedException {
 		claimLock.lock();
 		try {
-			return claimMatchingOrWaitUntilAvailable(predicate, timeout);
+			ensureOpenFor(attempt);
+			if (prepared.isInvalidationRequested()) {
+				throw new IllegalStateException("Resource invalidated during preparation");
+			}
+			return attempt.handOff(() -> {
+				finishReservation(reservation, prepared);
+				prepared.resetAllocationTimestamp();
+				prepared.setCurrentPoolStatus(PoolableObject.PoolStatus.CLAIMED);
+				currentlyClaimed++;
+				totalClaimed.incrementAndGet();
+			});
 		} finally {
 			claimLock.unlock();
+		}
+	}
+
+	private Throwable disposeFailedReservation(final Reservation reservation, final PoolableObject<T> prepared,
+			final ClaimAttempt attempt, final Throwable failure) {
+		claimLock.lock();
+		try {
+			finishReservation(reservation, prepared);
+			if (prepared != null) {
+				queueInvalidated(prepared);
+			}
+			signalAllWaitingClaimers();
+		} finally {
+			claimLock.unlock();
+		}
+		if (prepared != null && attempt.isControlled()) {
+			try {
+				// Cleanup must settle even when interrupted. join preserves the interrupt flag.
+				prepared.getDisposalCompletion().toCompletableFuture().join();
+			} catch (CompletionException cleanupFailure) {
+				if (failure == null) {
+					return cleanupFailure.getCause();
+				}
+				if (failure != cleanupFailure.getCause()) {
+					failure.addSuppressed(cleanupFailure.getCause());
+				}
+			}
+		}
+		return failure;
+	}
+
+	private void finishReservation(final Reservation reservation, final PoolableObject<T> prepared) {
+		pendingClaims--;
+		if (reservation.existing == null) {
+			pendingAllocations--;
+			if (prepared != null) {
+				currentlyAllocated++;
+				totalAllocated.incrementAndGet();
+			}
+		}
+	}
+
+	private static void rethrowFailure(final Throwable failure) throws InterruptedException {
+		if (failure instanceof InterruptedException) {
+			throw (InterruptedException) failure;
+		}
+		if (failure instanceof RuntimeException) {
+			throw (RuntimeException) failure;
+		}
+		if (failure instanceof Error) {
+			throw (Error) failure;
 		}
 	}
 
 	void releasePoolableObject(final PoolableObject<T> claimedObject) {
+		if (!beginRelease(claimedObject)) {
+			return;
+		}
+		Throwable failure = null;
+		allocatorLock.lock();
+		try {
+			allocator.deallocateForReuse(claimedObject.getAllocatedObject());
+		} catch (RuntimeException | Error releaseFailure) {
+			failure = releaseFailure;
+		} finally {
+			allocatorLock.unlock();
+			finishRelease(claimedObject, failure);
+		}
+		if (failure instanceof RuntimeException) {
+			throw (RuntimeException) failure;
+		}
+		if (failure instanceof Error) {
+			throw (Error) failure;
+		}
+	}
+
+	private boolean beginRelease(final PoolableObject<T> entry) {
 		claimLock.lock();
 		try {
-			if (isShuttingDown()) {
-				invalidatePoolableObject(claimedObject);
-			} else if (claimedObject.getCurrentPoolStatus() == PoolableObject.PoolStatus.CLAIMED) {
-				allocator.deallocateForReuse(claimedObject.getAllocatedObject());
-				currentlyClaimed.decrementAndGet();
-				claimedObject.resetAvailableTimestamp();
-				claimedObject.setCurrentPoolStatus(PoolableObject.PoolStatus.AVAILABLE);
-				available.addLast(claimedObject);
-
-				signalAllWaitingClaimers();
+			if (entry.getCurrentPoolStatus() != PoolableObject.PoolStatus.CLAIMED) {
+				return false;
 			}
+			currentlyClaimed--;
+			if (isShuttingDown()) {
+				queueInvalidated(entry);
+				return false;
+			}
+			entry.setCurrentPoolStatus(PoolableObject.PoolStatus.RELEASING);
+			return true;
 		} finally {
 			claimLock.unlock();
 		}
 	}
 
-	void invalidatePoolableObject(final PoolableObject<T> claimedObject) {
+	private void finishRelease(final PoolableObject<T> entry, final Throwable failure) {
 		claimLock.lock();
 		try {
-			if (claimedObject.getCurrentPoolStatus() == PoolableObject.PoolStatus.CLAIMED) {
-				currentlyClaimed.decrementAndGet();
-			} else if (claimedObject.getCurrentPoolStatus() == PoolableObject.PoolStatus.AVAILABLE) {
-				available.remove(claimedObject);
+			if (failure != null || isShuttingDown() || entry.isInvalidationRequested()) {
+				queueInvalidated(entry);
 			} else {
-				return;
+				entry.resetAvailableTimestamp();
+				entry.setCurrentPoolStatus(PoolableObject.PoolStatus.AVAILABLE);
+				available.addLast(entry);
 			}
-			// Publish invalidation before another release/invalidation can observe the old state.
-			addObjectForDeallocation(claimedObject);
-			// Waiting ordinary claims can now allocate a replacement, including in a lazy pool.
 			signalAllWaitingClaimers();
 		} finally {
 			claimLock.unlock();
 		}
 	}
 
-	private void addObjectForDeallocation(final PoolableObject<T> claimedObject) {
+	void invalidatePoolableObject(final PoolableObject<T> entry) {
+		claimLock.lock();
+		try {
+			switch (entry.getCurrentPoolStatus()) {
+				case PREPARING:
+				case RELEASING:
+					entry.setInvalidationRequested(true);
+					return;
+				case CLAIMED:
+					currentlyClaimed--;
+					break;
+				case AVAILABLE:
+					available.remove(entry);
+					break;
+				default:
+					return;
+			}
+			queueInvalidated(entry);
+		} finally {
+			claimLock.unlock();
+		}
+	}
+
+	/** Caller holds claimLock; publishing capacity and the disposal queue is one atomic transition. */
+	private void queueInvalidated(final PoolableObject<T> entry) {
 		deallocateLock.lock();
 		try {
-			waitingForDeallocation.add(claimedObject);
-			claimedObject.setCurrentPoolStatus(PoolableObject.PoolStatus.WAITING_FOR_DEALLOCATION);
+			currentlyAllocated--;
+			entry.setCurrentPoolStatus(PoolableObject.PoolStatus.WAITING_FOR_DEALLOCATION);
+			waitingForDeallocation.addLast(entry);
 			objectWaitingForDeallocation.signal();
 		} finally {
 			deallocateLock.unlock();
 		}
-	}
-
-	private PoolableObject<T> getObjectForDeallocation() {
-		PoolableObject<T> poolableObject = null;
-		deallocateLock.lock();
-		try {
-			if (!waitingForDeallocation.isEmpty()) {
-				currentlyDeallocating.incrementAndGet();
-				poolableObject = waitingForDeallocation.remove();
-			}
-		} finally {
-			deallocateLock.unlock();
-		}
-		return poolableObject;
-	}
-
-	@Nullable
-	private PoolableObject<T> waitForObjectForDeallocation() {
-		PoolableObject<T> poolableObject = null;
-		deallocateLock.lock();
-		try {
-			if (waitingForDeallocation.isEmpty() && !isShuttingDown()) {
-				final boolean deallocationAvailable = objectWaitingForDeallocation.await(DEALLOCATION_WAIT_MS, TimeUnit.MILLISECONDS);
-				if (!deallocationAvailable && waitingForDeallocation.isEmpty()) {
-					return null;
-				}
-			}
-			if (!waitingForDeallocation.isEmpty()) {
-				currentlyDeallocating.incrementAndGet();
-				poolableObject = waitingForDeallocation.remove();
-			}
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-		} finally {
-			deallocateLock.unlock();
-		}
-		return poolableObject;
-	}
-	
-	@Nullable
-	private PoolableObject<T> claimOrCreateOrWaitUntilAvailable(final Timeout timeout) throws InterruptedException, IllegalStateException {
-		PoolableObject<T> entry;
-		/*
-		 *	Try to claim an object or else wait for one to become available and then try again
-		 *	in between one becoming available and trying to claim again, it might have been
-		 *	snatched away by another thread.
-		 */
-		do {
-			if (isShuttingDown()) {
-				throw new IllegalStateException("Pool has been shutdown");
-			}
-			entry = claimOrCreateNewObjectIfSpaceLeft();
-		} while (entry == null && waitForAvailableObjectOrTimeout(timeout));
-		return entry;
-	}
-
-	@Nullable
-	private PoolableObject<T> claimMatchingOrWaitUntilAvailable(final Predicate<PoolableObject<T>> predicate, final Timeout timeout) throws InterruptedException, IllegalStateException {
-		final long deadlineMs = calculateDeadlineMs(timeout);
-		PoolableObject<T> entry;
-		do {
-			if (isShuttingDown()) {
-				throw new IllegalStateException("Pool has been shutdown");
-			}
-			entry = claimAvailableObjectMatching(predicate);
-		} while (entry == null && waitForMatchingObjectOrTimeout(deadlineMs));
-		return entry;
-	}
-	
-	@Nullable
-	private PoolableObject<T> claimOrCreateNewObjectIfSpaceLeft() {
-		PoolableObject<T> claimedObject = !available.isEmpty() ? available.removeFirst() : null;
-		if (claimedObject != null) {
-			prepareClaimedObjectForReuse(claimedObject);
-		} else if (getCurrentlyAllocated() < poolConfig.getMaxPoolsize()) {
-			claimedObject = new PoolableObject<>(this, allocator.allocate());
-			claimedObject.setCurrentPoolStatus(PoolableObject.PoolStatus.CLAIMED);
-			currentlyClaimed.incrementAndGet();
-			totalAllocated.incrementAndGet();
-			totalClaimed.incrementAndGet();
-		}
-		return claimedObject;
-	}
-
-	@Nullable
-	private PoolableObject<T> claimAvailableObjectMatching(final Predicate<PoolableObject<T>> predicate) {
-		for (Iterator<PoolableObject<T>> iterator = available.iterator(); iterator.hasNext(); ) {
-			final PoolableObject<T> poolableObject = iterator.next();
-			if (predicate.test(poolableObject)) {
-				iterator.remove();
-				prepareClaimedObjectForReuse(poolableObject);
-				return poolableObject;
-			}
-		}
-		return null;
-	}
-
-	private void prepareClaimedObjectForReuse(final PoolableObject<T> claimedObject) {
-		allocator.allocateForReuse(claimedObject.getAllocatedObject());
-		claimedObject.resetAllocationTimestamp();
-		claimedObject.setCurrentPoolStatus(PoolableObject.PoolStatus.CLAIMED);
-		currentlyClaimed.incrementAndGet();
-		totalClaimed.incrementAndGet();
-	}
-	
-	/**
-	 * Adds the current PoolWaitHelper into the waiting list.  The waitingClaimer will wait up until the specified deadline.  If the waitingClaimer is woken up before the specified deadline then true is returned
-	 * otherwise false.  The waitingClaimer will always be removed from the wait list regardless of the outcome.
-	 *
-	 * @param timeout the max timeout to wait for
-	 *
-	 * @return true if object became available
-	 * @throws InterruptedException the interrupted exception
-	 */
-	private boolean waitForAvailableObjectOrTimeout(final Timeout timeout) throws InterruptedException {
-		return waitForAvailableObjectOrTimeout(timeout.getDuration(), timeout.getTimeUnit());
-	}
-
-	private boolean waitForAvailableObjectOrTimeout(final long timeout, final TimeUnit timeUnit) throws InterruptedException {
-		final Condition objectAvailability = claimLock.newCondition();
-		try {
-			objectAvailableConditions.add(objectAvailability);
-			final boolean await = objectAvailability.await(timeout, timeUnit);
-			if (isShuttingDown()) {
-				throw new InterruptedException("Pool is shutting down");
-			}
-			return await;
-		} finally {
-			objectAvailableConditions.remove(objectAvailability);
-		}
-	}
-
-	private boolean waitForMatchingObjectOrTimeout(final long deadlineMs) throws InterruptedException {
-		final long remainingMs = deadlineMs - System.currentTimeMillis();
-		if (remainingMs <= 0) {
-			return false;
-		}
-		final long waitMs = Math.min(remainingMs, MATCHING_CLAIM_RECHECK_INTERVAL_MS);
-		return waitForAvailableObjectOrTimeout(waitMs, TimeUnit.MILLISECONDS) || System.currentTimeMillis() < deadlineMs;
-	}
-
-	private long calculateDeadlineMs(final Timeout timeout) {
-		final long now = System.currentTimeMillis();
-		final long durationMs = timeout.getDurationMs();
-		return durationMs >= Long.MAX_VALUE - now ? Long.MAX_VALUE : now + durationMs;
+		signalAllWaitingClaimers();
 	}
 
 	/**
-	 * Shuts down the current Pool stopping new allocations and triggering deallocations on all other available objects. Waits for
-	 * claimed objects to become available.
+	 * Stops new allocations and disposes available objects. Completes after borrowers return their objects,
+	 * outstanding preparation exits and final cleanup finishes.
 	 */
 	public synchronized Future<Void> shutdown() {
 		if (!isShuttingDown()) {
-			ExecutorService executorService = newSingleThreadExecutor(poolConfig.getThreadFactory());
-			shutdownSequence = executorService.submit(new ShutdownSequence(), null);
-			executorService.shutdown();
+			final FutureTask<Void> sequence = new FutureTask<>(new ShutdownSequence(), null);
+			shutdownSequence = sequence;
+			final ExecutorService executor = newSingleThreadExecutor(poolConfig.getThreadFactory());
+			executor.execute(sequence);
+			executor.shutdown();
 		}
 		return shutdownSequence;
 	}
-	
+
 	private boolean isShuttingDown() {
 		return shutdownSequence != null;
 	}
 
-	/**
-	 * Gets the allocation size.
-	 *
-	 * @return the allocation size
-	 */
-	@SuppressWarnings("WeakerAccess")
+	/** Gets the live allocation size, including preparation but excluding reservations and queued disposal. */
 	public int getCurrentlyAllocated() {
-		return available.size() + currentlyClaimed.get();
+		claimLock.lock();
+		try {
+			return currentlyAllocated;
+		} finally {
+			claimLock.unlock();
+		}
 	}
 
-	/**
-	 * @see PoolMetrics
-	 */
+	/** @see PoolMetrics */
 	@NotNull
 	public PoolMetrics getPoolMetrics() {
 		claimLock.lock();
 		try {
-			return new PoolMetrics(
-					currentlyClaimed.get(),
-					objectAvailableConditions.size(),
-					getCurrentlyAllocated(),
-					poolConfig.getCorePoolsize(),
-					poolConfig.getMaxPoolsize(),
-					totalAllocated.get(),
-					totalClaimed.get());
+			return new PoolMetrics(currentlyClaimed, waitingClaims.size(), currentlyAllocated, poolConfig.getCorePoolsize(),
+					poolConfig.getMaxPoolsize(), totalAllocated.get(), totalClaimed.get());
 		} finally {
 			claimLock.unlock();
 		}
 	}
 
-	private void deallocate(final PoolableObject<T> invalidatedObject) {
+	private PoolableObject<T> takeForDisposal(final boolean wait) {
+		deallocateLock.lock();
 		try {
-			allocator.deallocate(invalidatedObject.getAllocatedObject());
-		} catch (Exception e) {
-			log.error("error deallocating object already removed from the pool, ignoring it from now on...", e);
+			if (wait && waitingForDeallocation.isEmpty() && !isShuttingDown()) {
+				final boolean signalled = objectWaitingForDeallocation.await(DEALLOCATION_WAIT_MS, TimeUnit.MILLISECONDS);
+				if (!signalled && waitingForDeallocation.isEmpty()) {
+					return null;
+				}
+			}
+			if (waitingForDeallocation.isEmpty()) {
+				return null;
+			}
+			currentlyDeallocating.incrementAndGet();
+			return waitingForDeallocation.removeFirst();
+		} catch (InterruptedException interrupted) {
+			Thread.currentThread().interrupt();
+			return null;
+		} finally {
+			deallocateLock.unlock();
 		}
-		invalidatedObject.setCurrentPoolStatus(PoolableObject.PoolStatus.DEALLOCATED);
-		invalidatedObject.dereferenceObject();
+	}
+
+	private void disposeResource(final PoolableObject<T> entry) {
+		Throwable failure = null;
+		try {
+			allocator.deallocate(entry.getAllocatedObject());
+		} catch (RuntimeException | Error cleanupFailure) {
+			failure = cleanupFailure;
+			log.error("Error deallocating an object already removed from the pool", cleanupFailure);
+		} finally {
+			entry.dereferenceObject();
+			entry.setCurrentPoolStatus(PoolableObject.PoolStatus.DEALLOCATED);
+			entry.completeDisposal(failure);
+			currentlyDeallocating.decrementAndGet();
+		}
 	}
 
 	private void scheduleDeallocations() {
-		final ExpirationPolicy<T> expirationPolicy = poolConfig.getExpirationPolicy();
-		if (expirationPolicy == ExpirationPolicy.NeverExpirePolicy.getInstance()) {
-			return;
-		}
-		int objectsInvalidated = invalidateExpiredObjects(getExpiredObjects(expirationPolicy));
-        if (objectsInvalidated > 0) {
-			log.trace("{} objects invalidated as per expiration policy!", objectsInvalidated);
-        }
-	}
-
-	private int invalidateExpiredObjects(List<PoolableObject<T>> expiredObjects) {
-		int invalidatedObjects = 0;
 		claimLock.lock();
 		try {
-			for (final PoolableObject<T> poolableObject : expiredObjects) {
-				poolableObject.invalidate();
-				invalidatedObjects++;
-			}
-		} finally {
-			claimLock.unlock();
-		}
-		return invalidatedObjects;
-	}
-
-	private List<PoolableObject<T>> getExpiredObjects(ExpirationPolicy<T> expirationPolicy){
-		List<PoolableObject<T>> expiredObjects = new ArrayList<>();
-		claimLock.lock();
-		try {
-			for (final PoolableObject<T> poolableObject : available) {
-				if (expirationPolicy.hasExpired(poolableObject)) {
-					expiredObjects.add(poolableObject);
+			for (Iterator<PoolableObject<T>> iterator = available.iterator(); iterator.hasNext(); ) {
+				final PoolableObject<T> entry = iterator.next();
+				if (poolConfig.getExpirationPolicy().hasExpired(entry)) {
+					iterator.remove();
+					queueInvalidated(entry);
 				}
 			}
 		} finally {
 			claimLock.unlock();
 		}
-		return expiredObjects;
 	}
 
-	/**
-	 * <ol>
-	 *     <li>Automatically plan deallocation for expired objects</li>
-	 *     <li>Automatically deallocates one object every loop</li>
-	 * </ol>
-	 */
-	private class AutoDeallocator implements Runnable {
-
-		@Override
-		@SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH", justification = "False positive")
-		public void run() {
-			//noinspection ConstantConditions
-			while (shutdownSequence == null || !shutdownSequence.isDone() || !waitingForDeallocation.isEmpty()) {
-				deallocateOneOrPlanDeallocations();
-			}
-			log.debug("AutoDeallocator finished");
+	private Reservation reserveCoreAllocation() {
+		claimLock.lock();
+		try {
+			return !isShuttingDown() && currentlyAllocated + pendingAllocations < poolConfig.getCorePoolsize()
+					? reserveAllocation() : null;
+		} finally {
+			claimLock.unlock();
 		}
+	}
 
-		private void deallocateOneOrPlanDeallocations() {
-			final boolean shouldScheduleDeallocations = poolConfig.getExpirationPolicy() != ExpirationPolicy.NeverExpirePolicy.getInstance();
-			PoolableObject<T> poolableObject = shouldScheduleDeallocations ? getObjectForDeallocation() : waitForObjectForDeallocation();
-			final boolean deallocatedAnObject = poolableObject != null;
-			if (poolableObject != null) {
-				try {
-					deallocate(poolableObject);
-				} finally {
-					currentlyDeallocating.decrementAndGet();
+	private void replenishCore(final Reservation reservation) {
+		PoolableObject<T> entry = null;
+		allocatorLock.lock();
+		try {
+			// Core replenishment belongs to the pool, not to whichever caller happened to arrive first.
+			if (!isShuttingDown()) {
+				entry = new PoolableObject<>(this, requireNonNull(allocator.allocate(), "Allocated resource"));
+			}
+		} catch (RuntimeException failure) {
+			log.error("Unable to replenish the core pool; will retry", failure);
+		} finally {
+			allocatorLock.unlock();
+			publishCoreAllocation(reservation, entry);
+		}
+	}
+
+	private void publishCoreAllocation(final Reservation reservation, final PoolableObject<T> entry) {
+		claimLock.lock();
+		try {
+			finishReservation(reservation, entry);
+			if (entry != null) {
+				if (isShuttingDown()) {
+					queueInvalidated(entry);
+				} else {
+					available.addLast(entry);
 				}
 			}
-			if (!deallocatedAnObject && shouldScheduleDeallocations) {
-				scheduleDeallocations();
-			}
-			SleepUtil.sleep(isShuttingDown() ? 0 : deallocatedAnObject ? 50 : shouldScheduleDeallocations ? 10 : 0);
+			signalAllWaitingClaimers();
+		} finally {
+			claimLock.unlock();
 		}
 	}
 
-	/**
-	 * <ol>
-	 * <li>Automatically allocates objects until core pool size is met. Initially fills up the pool and when object are
-	 * deallocated.</li>
-	 * </ol>
-	 */
-	private class AutoAllocator implements Runnable {
+	private boolean maintenanceNeeded() {
+		final Future<Void> sequence = shutdownSequence;
+		return sequence == null || !sequence.isDone();
+	}
 
+	private void signalAllWaitingClaimers() {
+		for (ClaimAttempt attempt : waitingClaims) {
+			attempt.signal();
+		}
+	}
+
+	private final class Reservation {
+		private final PoolableObject<T> existing;
+
+		private Reservation(final PoolableObject<T> existing) {
+			this.existing = existing;
+		}
+	}
+
+	/** Existing maintenance worker: expiration and final disposal, independent of allocator preparation. */
+	private final class AutoDeallocator implements Runnable {
 		@Override
-		@SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH", justification = "False positive")
 		public void run() {
-			//noinspection ConstantConditions
-			while (shutdownSequence == null || !shutdownSequence.isDone() || !waitingForDeallocation.isEmpty()) {
-				allocatedCorePool();
+			while (maintenanceNeeded()) {
+				final boolean expires = poolConfig.getExpirationPolicy() != ExpirationPolicy.NeverExpirePolicy.getInstance();
+				final PoolableObject<T> entry = takeForDisposal(!expires);
+				if (entry != null) {
+					disposeResource(entry);
+				} else if (expires) {
+					scheduleDeallocations();
+				}
+				SleepUtil.sleep(isShuttingDown() ? 0 : entry != null ? 50 : expires ? 10 : 0);
+			}
+		}
+	}
+
+	/** Existing maintenance worker: reserves capacity before running pool-owned core allocation outside bookkeeping. */
+	private final class AutoAllocator implements Runnable {
+		@Override
+		public void run() {
+			while (maintenanceNeeded()) {
+				final Reservation reservation = reserveCoreAllocation();
+				if (reservation != null) {
+					replenishCore(reservation);
+				}
 				SleepUtil.sleep(5);
 			}
-			log.debug("AutoAllocator finished");
-		}
-
-		private void allocatedCorePool() {
-			claimLock.lock();
-			boolean addedObject = false;
-			try {
-				while (getCurrentlyAllocated() < poolConfig.getCorePoolsize() && !isShuttingDown()) {
-					available.addLast(new PoolableObject<>(GenericObjectPool.this, allocator.allocate()));
-					totalAllocated.incrementAndGet();
-					addedObject = true;
-				}
-			} catch (Exception e) {
-				log.error("Not able to allocate new object! This might be a temporary issue due to external reasons (a server rejecting a connection for example).", e);
-			} finally {
-				// Earlier allocations remain usable even if a later allocation in this batch failed.
-				if (addedObject) {
-					signalAllWaitingClaimers();
-				}
-				claimLock.unlock();
-			}
 		}
 	}
-	
-	private class ShutdownSequence implements Runnable {
-		
+
+	private final class ShutdownSequence implements Runnable {
 		@Override
 		public void run() {
-			initiateShutdown();
-			waitUntilShutDown();
-			log.info("Simple Object Pool shutdown complete");
-		}
-		
-		private void initiateShutdown() {
 			claimLock.lock();
 			try {
 				while (!available.isEmpty()) {
-					available.remove().invalidate();
+					queueInvalidated(available.removeFirst());
 				}
 				signalAllWaitingClaimers();
 			} finally {
 				claimLock.unlock();
 			}
-			signalObjectWaitingForDeallocation();
+			waitUntilShutDown();
+			log.info("Generic Object Pool shutdown complete");
 		}
-		
+
 		private void waitUntilShutDown() {
 			while (hasOutstandingWork()) {
 				SleepUtil.sleep(10);
@@ -511,35 +637,18 @@ public class GenericObjectPool<T> {
 		}
 
 		private boolean hasOutstandingWork() {
-			// Observe the claim-to-queue and queue-to-cleanup hand-offs as one consistent snapshot.
-			// Always take these locks in the same order as invalidation.
 			claimLock.lock();
 			try {
 				deallocateLock.lock();
 				try {
-					return currentlyClaimed.get() > 0 || currentlyDeallocating.get() > 0
-							|| !objectAvailableConditions.isEmpty() || !available.isEmpty() || !waitingForDeallocation.isEmpty();
+					return currentlyAllocated > 0 || pendingClaims > 0 || currentlyDeallocating.get() > 0
+							|| !waitingClaims.isEmpty() || !waitingForDeallocation.isEmpty();
 				} finally {
 					deallocateLock.unlock();
 				}
 			} finally {
 				claimLock.unlock();
 			}
-		}
-	}
-
-	private void signalAllWaitingClaimers() {
-		for (Condition condition : objectAvailableConditions) {
-			condition.signal();
-		}
-	}
-
-	private void signalObjectWaitingForDeallocation() {
-		deallocateLock.lock();
-		try {
-			objectWaitingForDeallocation.signal();
-		} finally {
-			deallocateLock.unlock();
 		}
 	}
 }

--- a/src/main/java/org/bbottema/genericobjectpool/PoolableObject.java
+++ b/src/main/java/org/bbottema/genericobjectpool/PoolableObject.java
@@ -8,6 +8,8 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 import static lombok.AccessLevel.PACKAGE;
 import static org.bbottema.genericobjectpool.PoolableObject.PoolStatus.AVAILABLE;
@@ -22,7 +24,7 @@ import static org.bbottema.genericobjectpool.PoolableObject.PoolStatus.DEALLOCAT
 public class PoolableObject<T> {
 	
 	enum PoolStatus {
-		AVAILABLE, CLAIMED, WAITING_FOR_DEALLOCATION, DEALLOCATED
+		AVAILABLE, PREPARING, CLAIMED, RELEASING, WAITING_FOR_DEALLOCATION, DEALLOCATED
 	}
 
 	@ToString.Exclude
@@ -49,7 +51,9 @@ public class PoolableObject<T> {
 	 * Performance optimisation: this field keeps track of the list this poolable object is in, so we don't have to do {@code .contains(object)}
 	 * all the time.
 	 */
-	@NotNull @Getter(PACKAGE) @Setter(PACKAGE) private PoolStatus currentPoolStatus;
+	@NotNull @Getter(PACKAGE) @Setter(PACKAGE) private volatile PoolStatus currentPoolStatus;
+	@ToString.Exclude private final CompletableFuture<Void> disposalCompletion = new CompletableFuture<>();
+	@Getter(PACKAGE) @Setter(PACKAGE) private boolean invalidationRequested;
 	
 	PoolableObject(GenericObjectPool<T> pool, @NotNull T allocatedObject) {
 		this.pool = pool;
@@ -74,6 +78,26 @@ public class PoolableObject<T> {
 	 */
 	public void invalidate() {
 		pool.invalidatePoolableObject(this);
+	}
+
+	/**
+	 * Completes after final deallocation returns, exceptionally if it fails. This is not claim or borrower-work
+	 * completion: a healthy {@link #release()} deliberately keeps the physical resource available for reuse.
+	 * Each call returns a detached view that cannot complete or cancel the pool's own cleanup signal.
+	 * Non-async completion handlers may run on the cleanup worker; keep them non-blocking, or use an async handler.
+	 *
+	 * @since 2.5.0
+	 */
+	public CompletionStage<Void> getDisposalCompletion() {
+		return disposalCompletion.thenApply(ignored -> null);
+	}
+
+	void completeDisposal(final Throwable failure) {
+		if (failure == null) {
+			disposalCompletion.complete(null);
+		} else {
+			disposalCompletion.completeExceptionally(failure);
+		}
 	}
 	
 	void resetAllocationTimestamp() {

--- a/src/test/compatibility/LegacyAllocatorClient.java
+++ b/src/test/compatibility/LegacyAllocatorClient.java
@@ -1,0 +1,31 @@
+import org.bbottema.genericobjectpool.Allocator;
+import org.bbottema.genericobjectpool.GenericObjectPool;
+import org.bbottema.genericobjectpool.PoolConfig;
+import org.bbottema.genericobjectpool.PoolableObject;
+
+import java.util.concurrent.TimeUnit;
+
+/** Compiled against 2.4.3, then run unchanged against the candidate JAR. */
+public final class LegacyAllocatorClient {
+	public static void main(final String[] args) throws Exception {
+		final GenericObjectPool<String> pool = new GenericObjectPool<>(PoolConfig.<String>builder().maxPoolsize(1).build(),
+				new Allocator<String>() {
+					@Override public String allocate() { return "legacy"; }
+				});
+		try {
+			final PoolableObject<String> first = pool.claim(2, TimeUnit.SECONDS);
+			if (first == null || !"legacy".equals(first.getAllocatedObject())) {
+				throw new AssertionError("Legacy claim failed");
+			}
+			first.release();
+			final PoolableObject<String> reused = pool.claimMatching(value -> true, 2, TimeUnit.SECONDS);
+			if (reused != first) {
+				throw new AssertionError("Legacy matching claim did not reuse the object");
+			}
+			reused.invalidate();
+		} finally {
+			pool.shutdown().get(5, TimeUnit.SECONDS);
+		}
+		System.out.println("Previously compiled allocator and claim API: OK");
+	}
+}

--- a/src/test/compatibility/consumer/PoolApiConsumer.java
+++ b/src/test/compatibility/consumer/PoolApiConsumer.java
@@ -1,0 +1,38 @@
+package consumer;
+
+import org.bbottema.genericobjectpool.AllocationContext;
+import org.bbottema.genericobjectpool.Allocator;
+import org.bbottema.genericobjectpool.ClaimControl;
+import org.bbottema.genericobjectpool.ClaimOptions;
+import org.bbottema.genericobjectpool.GenericObjectPool;
+import org.bbottema.genericobjectpool.PoolConfig;
+import org.bbottema.genericobjectpool.PoolableObject;
+
+import java.util.concurrent.TimeUnit;
+
+/** Runs on both the classpath and module path without a test framework. */
+public final class PoolApiConsumer {
+	public static void main(final String[] args) throws Exception {
+		final ClaimControl control = new ClaimControl();
+		final GenericObjectPool<String> pool = new GenericObjectPool<>(PoolConfig.<String>builder().maxPoolsize(1).build(),
+				new Allocator<String>() {
+					@Override public String allocate() { return "legacy"; }
+					@Override public String allocate(final AllocationContext context) {
+						context.throwIfCancellationRequested();
+						return "controlled";
+					}
+				});
+		try {
+			final PoolableObject<String> lease = pool.claim(ClaimOptions.withTimeout(2, TimeUnit.SECONDS).withClaimControl(control));
+			if (lease == null || !"controlled".equals(lease.getAllocatedObject())) {
+				throw new AssertionError("Context-aware claim failed");
+			}
+			control.requestCancellation();
+			lease.invalidate();
+			lease.getDisposalCompletion().toCompletableFuture().get(5, TimeUnit.SECONDS);
+		} finally {
+			pool.shutdown().get(5, TimeUnit.SECONDS);
+		}
+		System.out.println("Opt-in claim API: OK");
+	}
+}

--- a/src/test/compatibility/module-info.java
+++ b/src/test/compatibility/module-info.java
@@ -1,0 +1,3 @@
+module pool.compatibility.consumer {
+	requires org.bbottema.genericobjectpool;
+}

--- a/src/test/java/org/bbottema/genericobjectpool/ClaimControlTest.java
+++ b/src/test/java/org/bbottema/genericobjectpool/ClaimControlTest.java
@@ -1,0 +1,61 @@
+package org.bbottema.genericobjectpool;
+
+import org.bbottema.genericobjectpool.util.Timeout;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ClaimControlTest {
+	@Test
+	void controlIsOptInOneShotAndOptionsAreImmutable() {
+		final ClaimControl control = new ClaimControl();
+		final ClaimOptions plain = ClaimOptions.withTimeout(30, SECONDS);
+		final AllocationContext attached = plain.withClaimControl(control).start();
+		assertThat(attached.isCancellationRequested()).isFalse();
+		assertThat(control.requestCancellation()).isTrue();
+		assertThat(control.requestCancellation()).isFalse();
+		assertThat(attached.isCancellationRequested()).isTrue();
+		assertThat(plain.start().isCancellationRequested()).isFalse();
+		assertThatThrownBy(attached::throwIfCancellationRequested).isInstanceOf(CancellationException.class);
+	}
+
+	@Test
+	void validatesOptionsAndSaturatesHugeDurations() {
+		assertThatThrownBy(() -> ClaimOptions.withTimeout(-1, SECONDS)).isInstanceOf(IllegalArgumentException.class);
+		assertThatThrownBy(() -> ClaimOptions.withTimeout(1, null)).isInstanceOf(NullPointerException.class);
+		assertThatThrownBy(() -> ClaimOptions.withoutTimeout().withClaimControl(null)).isInstanceOf(NullPointerException.class);
+		assertThat(ClaimOptions.withTimeout(0, SECONDS).start().isTimedOut()).isTrue();
+		assertThat(ClaimOptions.withTimeout(Long.MAX_VALUE, DAYS).start().getRemainingTime(NANOSECONDS)).isEqualTo(Long.MAX_VALUE);
+	}
+
+	@Test
+	void limitingAnOuterBudgetDoesNotRestartItsClock() {
+		final AllocationContext elapsed = new AllocationContext(System.nanoTime() - SECONDS.toNanos(5), SECONDS.toNanos(10), null);
+		assertThat(elapsed.limitedTo(new Timeout(3, SECONDS)).isTimedOut()).isTrue();
+		assertThat(elapsed.limitedTo(new Timeout(30, SECONDS)).getRemainingTime(SECONDS)).isBetween(3L, 5L);
+	}
+
+	@Test
+	void handlersAreRemovedIsolatedAndInvokedForEarlierRequests() {
+		final ClaimControl control = new ClaimControl();
+		final AllocationContext context = ClaimOptions.withoutTimeout().withClaimControl(control).start();
+		final AtomicInteger calls = new AtomicInteger();
+		context.onCancellation(calls::incrementAndGet).close();
+		context.onCancellation(() -> { throw new IllegalStateException("test handler"); });
+		context.onCancellation(calls::incrementAndGet);
+		control.requestCancellation();
+		assertThat(calls.get()).isEqualTo(1);
+		context.onCancellation(calls::incrementAndGet);
+		assertThat(calls.get()).isEqualTo(2);
+		context.detachCancellationHandlers();
+		context.detachCancellationHandlers();
+		assertThatThrownBy(() -> context.onCancellation(calls::incrementAndGet)).isInstanceOf(IllegalStateException.class);
+	}
+}

--- a/src/test/java/org/bbottema/genericobjectpool/ControlledClaimTest.java
+++ b/src/test/java/org/bbottema/genericobjectpool/ControlledClaimTest.java
@@ -1,0 +1,582 @@
+package org.bbottema.genericobjectpool;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.bbottema.genericobjectpool.PoolTestResources.await;
+import static org.bbottema.genericobjectpool.PoolTestResources.result;
+
+class ControlledClaimTest {
+
+	private final PoolTestResources resources = new PoolTestResources();
+
+	@AfterEach
+	void cleanUp() throws Exception {
+		resources.close();
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	void preCancelledAndZeroBudgetNeverPrepare(final boolean matching) throws Exception {
+		final CountingAllocator allocator = new CountingAllocator();
+		final GenericObjectPool<Integer> pool = pool(0, 1, allocator);
+		final ClaimControl control = new ClaimControl();
+		control.requestCancellation();
+		assertThatThrownBy(() -> claim(pool, matching, options(control))).isInstanceOf(CancellationException.class);
+		assertThat(claim(pool, matching, ClaimOptions.withTimeout(0, SECONDS))).isNull();
+		assertThat(allocator.created.get()).isZero();
+		assertThat(pool.getPoolMetrics().getCurrentlyWaitingCount()).isZero();
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	void cancellationOnlyWakesItsWaiterAndDoesNotInterruptTheNextJob(final boolean matching) throws Exception {
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator());
+		final PoolableObject<Integer> held = resources.remember(pool.claim());
+		final ClaimControl control = new ClaimControl();
+		final ExecutorService worker = resources.singleWorker();
+		final Future<?> cancelled = worker.submit(() -> claim(pool, matching, options(control)));
+		final Future<PoolableObject<Integer>> survivor = resources.workers.submit(() -> claim(pool, matching, ClaimOptions.withoutTimeout()));
+		await("both claims waiting", () -> pool.getPoolMetrics().getCurrentlyWaitingCount() == 2);
+		assertThat(control.requestCancellation()).isTrue();
+		assertThatThrownBy(() -> result(cancelled)).hasCauseInstanceOf(CancellationException.class);
+		assertThat(result(worker.submit(() -> Thread.currentThread().isInterrupted()))).isFalse();
+		assertThat(survivor.isDone()).isFalse();
+		held.release();
+		assertThat(result(survivor)).isSameAs(held);
+	}
+
+	@Test
+	void poolLockContentionIsCancellable() throws Exception {
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator());
+		final ReentrantLock lock = internalLock(pool, "claimLock");
+		final ClaimControl control = new ClaimControl();
+		lock.lock();
+		try {
+			final Future<?> pending = resources.workers.submit(() -> pool.claim(options(control)));
+			await("waiting for bookkeeping lock", lock::hasQueuedThreads);
+			control.requestCancellation();
+			assertThatThrownBy(() -> result(pending)).hasCauseInstanceOf(CancellationException.class);
+		} finally {
+			lock.unlock();
+		}
+	}
+
+	@Test
+	void allocatorGateContentionDoesNotBlockCancellationOrMetrics() throws Exception {
+		final CountDownLatch entered = new CountDownLatch(1);
+		final CountDownLatch finish = new CountDownLatch(1);
+		final GenericObjectPool<Integer> pool = pool(0, 2, new CountingAllocator() {
+			@Override public Integer allocate() {
+				entered.countDown();
+				awaitLatch(finish);
+				return super.allocate();
+			}
+		});
+		try {
+			final Future<?> first = resources.workers.submit(() -> resources.remember(pool.claim()));
+			awaitLatch(entered);
+			final ClaimControl control = new ClaimControl();
+			final Future<?> second = resources.workers.submit(() -> pool.claim(options(control)));
+			await("waiting for allocator gate", () -> internalLock(pool, "allocatorLock").hasQueuedThreads());
+			assertThat(pool.getPoolMetrics().getCurrentlyClaimed()).isZero();
+			control.requestCancellation();
+			assertThatThrownBy(() -> result(second)).hasCauseInstanceOf(CancellationException.class);
+			assertThat(first.isDone()).isFalse();
+			finish.countDown();
+			result(first);
+		} finally {
+			finish.countDown();
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	void latePreparationIsDisposedBeforeCancellationSettles(final boolean reuse) throws Exception {
+		final CountDownLatch preparing = new CountDownLatch(1);
+		final CountDownLatch finishPreparation = new CountDownLatch(1);
+		final CountDownLatch disposing = new CountDownLatch(1);
+		final CountDownLatch finishDisposal = new CountDownLatch(1);
+		final CountingAllocator allocator = new CountingAllocator() {
+			@Override public Integer allocate(final AllocationContext context) {
+				preparing.countDown();
+				awaitLatch(finishPreparation);
+				return super.allocate();
+			}
+			@Override public void allocateForReuse(final Integer resource, final AllocationContext context) {
+				preparing.countDown();
+				awaitLatch(finishPreparation);
+			}
+			@Override public void deallocate(final Integer resource) {
+				disposing.countDown();
+				awaitLatch(finishDisposal);
+				super.deallocate(resource);
+			}
+		};
+		final GenericObjectPool<Integer> pool = pool(0, 1, allocator);
+		if (reuse) {
+			resources.remember(pool.claim()).release();
+		}
+		try {
+			final ClaimControl control = new ClaimControl();
+			final Future<?> pending = resources.workers.submit(() -> pool.claim(options(control)));
+			awaitLatch(preparing);
+			control.requestCancellation();
+			assertThat(pending.isDone()).isFalse();
+			finishPreparation.countDown();
+			awaitLatch(disposing);
+			assertThat(pending.isDone()).isFalse();
+			assertThat(pool.getPoolMetrics().getCurrentlyClaimed()).isZero();
+			final Future<Void> shutdown = pool.shutdown();
+			assertThat(shutdown.isDone()).isFalse();
+			finishDisposal.countDown();
+			assertThatThrownBy(() -> result(pending)).hasCauseInstanceOf(CancellationException.class);
+			result(shutdown);
+			assertThat(allocator.disposed.get()).isEqualTo(1);
+			assertThat(pool.getCurrentlyAllocated()).isZero();
+		} finally {
+			finishPreparation.countDown();
+			finishDisposal.countDown();
+		}
+	}
+
+	@Test
+	void cooperativeHookCanUnblockPreparationAndIsDetachedAtHandoff() throws Exception {
+		final AtomicReference<AllocationContext> captured = new AtomicReference<>();
+		final AtomicInteger aborts = new AtomicInteger();
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator() {
+			@Override public Integer allocate(final AllocationContext context) {
+				captured.set(context);
+				context.onCancellation(aborts::incrementAndGet);
+				return super.allocate();
+			}
+		});
+		final ClaimControl control = new ClaimControl();
+		final PoolableObject<Integer> first = resources.remember(pool.claim(options(control)));
+		first.release();
+		final PoolableObject<Integer> second = resources.remember(pool.claim());
+		control.requestCancellation();
+		assertThat(aborts.get()).isZero();
+		assertThat(second.getAllocatedObject()).isEqualTo(1);
+		assertThatThrownBy(() -> captured.get().onCancellation(aborts::incrementAndGet)).isInstanceOf(IllegalStateException.class);
+	}
+
+	@Test
+	void cancellationHandlerUnblocksCooperativeAllocation() throws Exception {
+		final CountDownLatch started = new CountDownLatch(1);
+		final CountDownLatch abort = new CountDownLatch(1);
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator() {
+			@Override public Integer allocate(final AllocationContext context) {
+				context.onCancellation(abort::countDown);
+				started.countDown();
+				awaitLatch(abort);
+				context.throwIfCancellationRequested();
+				return super.allocate();
+			}
+		});
+		try {
+			final ClaimControl control = new ClaimControl();
+			final Future<?> pending = resources.workers.submit(() -> pool.claim(options(control)));
+			awaitLatch(started);
+			control.requestCancellation();
+			assertThatThrownBy(() -> result(pending)).hasCauseInstanceOf(CancellationException.class);
+			assertThat(pool.getPoolMetrics().getTotalAllocated()).isZero();
+		} finally {
+			abort.countDown();
+		}
+	}
+
+	@Test
+	void cooperativeAbortFailureIsTheCauseOfCancellation() throws Exception {
+		final CountDownLatch started = new CountDownLatch(1);
+		final CountDownLatch abort = new CountDownLatch(1);
+		final IllegalStateException closed = new IllegalStateException("connection aborted");
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator() {
+			@Override public Integer allocate(final AllocationContext context) {
+				context.onCancellation(abort::countDown);
+				started.countDown();
+				awaitLatch(abort);
+				throw closed;
+			}
+		});
+		try {
+			final ClaimControl control = new ClaimControl();
+			final Future<?> pending = resources.workers.submit(() -> pool.claim(options(control)));
+			awaitLatch(started);
+			control.requestCancellation();
+			try {
+				result(pending);
+				throw new AssertionError("Claim should be cancelled");
+			} catch (ExecutionException failure) {
+				assertThat(failure.getCause()).isInstanceOf(CancellationException.class).hasCause(closed);
+			}
+		} finally {
+			abort.countDown();
+		}
+	}
+
+	@Test
+	void disposalCompletionCannotBeForgedAndCleanupFailureIsVisible() throws Exception {
+		final CountDownLatch disposing = new CountDownLatch(1);
+		final CountDownLatch finish = new CountDownLatch(1);
+		final IllegalStateException failure = new IllegalStateException("cleanup failed");
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator() {
+			@Override public void deallocate(final Integer resource) {
+				disposing.countDown();
+				awaitLatch(finish);
+				throw failure;
+			}
+		});
+		try {
+			final PoolableObject<Integer> lease = resources.remember(pool.claim());
+			final CompletableFuture<Void> fake = lease.getDisposalCompletion().toCompletableFuture();
+			fake.complete(null);
+			lease.release();
+			assertThat(lease.getDisposalCompletion().toCompletableFuture().isDone()).isFalse();
+			lease.invalidate();
+			awaitLatch(disposing);
+			assertThat(lease.getDisposalCompletion().toCompletableFuture().isDone()).isFalse();
+			finish.countDown();
+			assertThatThrownBy(() -> result(lease.getDisposalCompletion().toCompletableFuture())).hasCause(failure);
+		} finally {
+			finish.countDown();
+		}
+	}
+
+	@Test
+	void releasePreparationDoesNotHoldBookkeepingAndShutdownIncludesIt() throws Exception {
+		final CountDownLatch releasing = new CountDownLatch(1);
+		final CountDownLatch finish = new CountDownLatch(1);
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator() {
+			@Override public void deallocateForReuse(final Integer resource) {
+				releasing.countDown();
+				awaitLatch(finish);
+			}
+		});
+		try {
+			final PoolableObject<Integer> lease = resources.remember(pool.claim());
+			final Future<?> release = resources.workers.submit(lease::release);
+			awaitLatch(releasing);
+			assertThat(pool.getCurrentlyAllocated()).isEqualTo(1);
+			final ClaimControl control = new ClaimControl();
+			final Future<?> pending = resources.workers.submit(() -> pool.claim(options(control)));
+			await("waiter while release is blocked", () -> pool.getPoolMetrics().getCurrentlyWaitingCount() == 1);
+			control.requestCancellation();
+			assertThatThrownBy(() -> result(pending)).hasCauseInstanceOf(CancellationException.class);
+			lease.invalidate();
+			final Future<Void> shutdown = pool.shutdown();
+			assertThat(shutdown.isDone()).isFalse();
+			finish.countDown();
+			result(release);
+			result(shutdown);
+		} finally {
+			finish.countDown();
+		}
+	}
+
+	@Test
+	void coreAllocationIsPoolOwnedAndSurvivesCancellationOfAWaiter() throws Exception {
+		final CountDownLatch allocating = new CountDownLatch(1);
+		final CountDownLatch finish = new CountDownLatch(1);
+		final GenericObjectPool<Integer> pool = pool(1, 1, new CountingAllocator() {
+			@Override public Integer allocate() {
+				allocating.countDown();
+				awaitLatch(finish);
+				return super.allocate();
+			}
+		});
+		try {
+			awaitLatch(allocating);
+			final ClaimControl control = new ClaimControl();
+			final Future<?> pending = resources.workers.submit(() -> pool.claim(options(control)));
+			await("waiting for core allocation", () -> pool.getPoolMetrics().getCurrentlyWaitingCount() == 1);
+			control.requestCancellation();
+			assertThatThrownBy(() -> result(pending)).hasCauseInstanceOf(CancellationException.class);
+			finish.countDown();
+			assertThat(resources.remember(pool.claim()).getAllocatedObject()).isEqualTo(1);
+		} finally {
+			finish.countDown();
+		}
+	}
+
+	@Test
+	void expiryAndInterruptionAreDistinctAndMatchingNeverAllocates() throws Exception {
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator());
+		assertThat(pool.claimMatching(value -> true, ClaimOptions.withTimeout(30, MILLISECONDS))).isNull();
+		assertThat(pool.getPoolMetrics().getTotalAllocated()).isZero();
+		resources.remember(pool.claim());
+		final AtomicReference<Thread> thread = new AtomicReference<>();
+		final Future<?> pending = resources.workers.submit(() -> {
+			thread.set(Thread.currentThread());
+			return pool.claim(ClaimOptions.withoutTimeout());
+		});
+		await("waiter registered", () -> pool.getPoolMetrics().getCurrentlyWaitingCount() == 1);
+		thread.get().interrupt();
+		assertThatThrownBy(() -> result(pending)).hasCauseInstanceOf(InterruptedException.class);
+	}
+
+	@Test
+	void handoffRacesNeverLeakCapacityOrAffectTheNextBorrower() throws Exception {
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator());
+		for (int round = 0; round < 50; round++) {
+			final ClaimControl control = new ClaimControl();
+			final CyclicBarrier start = new CyclicBarrier(2);
+			final Future<PoolableObject<Integer>> pending = resources.workers.submit(() -> {
+				start.await(5, SECONDS);
+				return resources.remember(pool.claim(options(control)));
+			});
+			start.await(5, SECONDS);
+			control.requestCancellation();
+			try {
+				final PoolableObject<Integer> lease = result(pending);
+				assertThat(lease.getAllocatedObject()).isNotNull();
+				lease.release();
+			} catch (ExecutionException failure) {
+				assertThat(failure.getCause()).isInstanceOf(CancellationException.class);
+			}
+			final PoolableObject<Integer> next = resources.remember(pool.claim());
+			assertThat(pool.getCurrentlyAllocated()).isEqualTo(1);
+			assertThat(pool.getPoolMetrics().getCurrentlyClaimed()).isEqualTo(1);
+			next.release();
+		}
+	}
+
+	@Test
+	void allocationCallbacksRemainSerializedAndReservationsRespectCapacity() throws Exception {
+		final AtomicInteger callbacks = new AtomicInteger();
+		final AtomicInteger maxCallbacks = new AtomicInteger();
+		final CountingAllocator allocator = new CountingAllocator() {
+			@Override public Integer allocate() {
+				maxCallbacks.accumulateAndGet(callbacks.incrementAndGet(), Math::max);
+				try {
+					return super.allocate();
+				} finally {
+					callbacks.decrementAndGet();
+				}
+			}
+		};
+		final GenericObjectPool<Integer> pool = pool(1, 3, allocator);
+		final List<Future<?>> jobs = new ArrayList<>();
+		for (int i = 0; i < 20; i++) {
+			jobs.add(resources.workers.submit(() -> {
+				final PoolableObject<Integer> lease = resources.remember(pool.claim(ClaimOptions.withTimeout(3, SECONDS)));
+				assertThat(lease).isNotNull();
+				lease.release();
+				return null;
+			}));
+		}
+		for (Future<?> job : jobs) {
+			result(job);
+		}
+		assertThat(maxCallbacks.get()).isEqualTo(1);
+		assertThat(allocator.created.get()).isLessThanOrEqualTo(3);
+	}
+
+	@Test
+	void repeatedSignalsDoNotRestartTheTotalBudget() throws Exception {
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator());
+		final AtomicInteger checks = new AtomicInteger();
+		final AtomicBoolean signal = new AtomicBoolean(true);
+		final Future<?> signalling = resources.workers.submit(() -> {
+			while (signal.get()) {
+				final ReentrantLock lock = internalLock(pool, "claimLock");
+				lock.lock();
+				try {
+					for (ClaimAttempt waiter : waitingClaims(pool)) {
+						waiter.signal();
+					}
+				} finally {
+					lock.unlock();
+				}
+				Thread.yield();
+			}
+		});
+		try {
+			resources.remember(pool.claim()).release();
+			final long started = System.nanoTime();
+			assertThat(pool.claimMatching(lease -> { checks.incrementAndGet(); return false; },
+					ClaimOptions.withTimeout(80, MILLISECONDS))).isNull();
+			assertThat(checks.get()).isGreaterThan(1);
+			assertThat(MILLISECONDS.convert(System.nanoTime() - started, NANOSECONDS)).isLessThan(1500L);
+		} finally {
+			signal.set(false);
+			result(signalling);
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {false, true})
+	void lateAllocationCannotEscapeAfterTimeoutOrInterruption(final boolean interrupt) throws Exception {
+		final CountDownLatch entered = new CountDownLatch(1);
+		final CountDownLatch finish = new CountDownLatch(1);
+		final AtomicReference<AllocationContext> context = new AtomicReference<>();
+		final AtomicReference<Thread> worker = new AtomicReference<>();
+		final CountingAllocator allocator = new CountingAllocator() {
+			@Override public Integer allocate(final AllocationContext current) {
+				context.set(current);
+				entered.countDown();
+				boolean interrupted = false;
+				while (true) {
+					try {
+						assertThat(finish.await(5, SECONDS)).isTrue();
+						break;
+					} catch (InterruptedException ignored) {
+						interrupted = true;
+					}
+				}
+				if (interrupted) {
+					Thread.currentThread().interrupt();
+				}
+				return super.allocate();
+			}
+		};
+		final GenericObjectPool<Integer> pool = pool(0, 1, allocator);
+		try {
+			final Future<?> pending = resources.workers.submit(() -> {
+				worker.set(Thread.currentThread());
+				return pool.claim(ClaimOptions.withTimeout(interrupt ? 5000 : 80, MILLISECONDS));
+			});
+			awaitLatch(entered);
+			if (interrupt) {
+				worker.get().interrupt();
+			} else {
+				await("allocation budget expired", () -> context.get().isTimedOut());
+			}
+			finish.countDown();
+			if (interrupt) {
+				assertThatThrownBy(() -> result(pending)).hasCauseInstanceOf(InterruptedException.class);
+			} else {
+				assertThat(result(pending)).isNull();
+			}
+			assertThat(allocator.disposed.get()).isEqualTo(1);
+			assertThat(pool.getCurrentlyAllocated()).isZero();
+		} finally {
+			finish.countDown();
+		}
+	}
+
+	@Test
+	void reuseFailureKeepsItsIdentityAndSuppressedCleanupFailure() throws Exception {
+		final IllegalStateException preparation = new IllegalStateException("reuse failed");
+		final IllegalStateException cleanup = new IllegalStateException("cleanup failed");
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator() {
+			@Override public void allocateForReuse(final Integer resource) { throw preparation; }
+			@Override public void deallocate(final Integer resource) { throw cleanup; }
+		});
+		resources.remember(pool.claim()).release();
+		assertThatThrownBy(() -> pool.claim(ClaimOptions.withoutTimeout())).isSameAs(preparation);
+		assertThat(preparation.getSuppressed()).containsExactly(cleanup);
+		assertThat(pool.getCurrentlyAllocated()).isZero();
+		assertThat(resources.remember(pool.claim()).getAllocatedObject()).isEqualTo(2);
+	}
+
+	@Test
+	void failedReleaseInvalidatesAndRestoresCapacity() throws Exception {
+		final IllegalStateException failure = new IllegalStateException("release failed");
+		final GenericObjectPool<Integer> pool = pool(0, 1, new CountingAllocator() {
+			@Override public void deallocateForReuse(final Integer resource) { throw failure; }
+		});
+		final PoolableObject<Integer> first = resources.remember(pool.claim());
+		assertThatThrownBy(first::release).isSameAs(failure);
+		result(first.getDisposalCompletion().toCompletableFuture());
+		assertThat(resources.remember(pool.claim()).getAllocatedObject()).isEqualTo(2);
+	}
+
+	@Test
+	void shutdownDuringForegroundPreparationWaitsAndDisposesTheLateObject() throws Exception {
+		final CountDownLatch entered = new CountDownLatch(1);
+		final CountDownLatch finish = new CountDownLatch(1);
+		final CountingAllocator allocator = new CountingAllocator() {
+			@Override public Integer allocate() {
+				entered.countDown();
+				awaitLatch(finish);
+				return super.allocate();
+			}
+		};
+		final GenericObjectPool<Integer> pool = pool(0, 1, allocator);
+		try {
+			final Future<?> pending = resources.workers.submit(() -> pool.claim(ClaimOptions.withoutTimeout()));
+			awaitLatch(entered);
+			final Future<Void> shutdown = pool.shutdown();
+			assertThat(shutdown.isDone()).isFalse();
+			finish.countDown();
+			assertThatThrownBy(() -> result(pending)).hasCauseInstanceOf(IllegalStateException.class);
+			result(shutdown);
+			assertThat(allocator.disposed.get()).isEqualTo(1);
+		} finally {
+			finish.countDown();
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private static List<ClaimAttempt> waitingClaims(final GenericObjectPool<?> pool) {
+		try {
+			final Field field = GenericObjectPool.class.getDeclaredField("waitingClaims");
+			field.setAccessible(true);
+			return (List<ClaimAttempt>) field.get(pool);
+		} catch (ReflectiveOperationException failure) {
+			throw new AssertionError(failure);
+		}
+	}
+
+	private GenericObjectPool<Integer> pool(final int core, final int max, final Allocator<Integer> allocator) {
+		return resources.pool(PoolConfig.<Integer>builder().corePoolsize(core).maxPoolsize(max).build(), allocator);
+	}
+
+	private PoolableObject<Integer> claim(final GenericObjectPool<Integer> pool, final boolean matching, final ClaimOptions options)
+			throws InterruptedException {
+		return resources.remember(matching ? pool.claimMatching(value -> true, options) : pool.claim(options));
+	}
+
+	private static ClaimOptions options(final ClaimControl control) {
+		return ClaimOptions.withTimeout(5, SECONDS).withClaimControl(control);
+	}
+
+	private static ReentrantLock internalLock(final GenericObjectPool<?> pool, final String name) {
+		try {
+			final Field field = GenericObjectPool.class.getDeclaredField(name);
+			field.setAccessible(true);
+			return (ReentrantLock) field.get(pool);
+		} catch (ReflectiveOperationException failure) {
+			throw new AssertionError(failure);
+		}
+	}
+
+	private static void awaitLatch(final CountDownLatch latch) {
+		try {
+			assertThat(latch.await(5, SECONDS)).as("test latch released").isTrue();
+		} catch (InterruptedException interrupted) {
+			Thread.currentThread().interrupt();
+			throw new AssertionError(interrupted);
+		}
+	}
+
+	private static class CountingAllocator extends Allocator<Integer> {
+		final AtomicInteger created = new AtomicInteger();
+		final AtomicInteger disposed = new AtomicInteger();
+		@Override public Integer allocate() { return created.incrementAndGet(); }
+		@Override public void deallocate(final Integer resource) { disposed.incrementAndGet(); }
+	}
+}

--- a/src/test/java/org/bbottema/genericobjectpool/WaiterRecoveryTest.java
+++ b/src/test/java/org/bbottema/genericobjectpool/WaiterRecoveryTest.java
@@ -240,7 +240,8 @@ class WaiterRecoveryTest {
 			awaitWaiters(pool, 1);
 			startMaintenance.countDown();
 			assertThat(result(first).getAllocatedObject()).isEqualTo(1);
-			assertThat(failures.get()).isPositive();
+			// Publishing each allocation no longer holds the claim lock across the following allocator callback.
+			await("a subsequent core allocation failed", () -> failures.get() > 0);
 			assertThat(pool.getPoolMetrics().getTotalAllocated()).isEqualTo(1);
 
 			final Future<PoolableObject<Integer>> second = resources.workers.submit(() -> resources.remember(


### PR DESCRIPTION
Adds opt-in `ClaimOptions` / `ClaimControl` for pending acquisition, cooperative allocator hooks, and final-disposal acknowledgement. Existing claim methods and compiled allocator subclasses remain supported on Java 8.

Preparation runs outside bookkeeping while retaining per-pool allocator serialization. Cancellation ends at resource handoff; a late resource is disposed instead of escaping to a cancelled caller.

Verified the Java 8 release build, all 85 tests on Java 8 and Java 21, previously compiled 2.4.3 clients, and classpath/module-path consumers.

Refs #22 and bbottema/simple-java-mail#726. Release target: 2.5.0. The issue remains open until publication.